### PR TITLE
chore: update ktsu.Sdk to 2.21.1 [patch]

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -9,7 +9,9 @@ charset = utf-8
 indent_style = space
 indent_size = 4
 tab_width = 4
-end_of_line = crlf
+# LF on every platform, matching the `* text=auto eol=lf` default in .gitattributes.
+# Overrides below must stay in step with the eol pins in that file.
+end_of_line = lf
 insert_final_newline = true
 trim_trailing_whitespace = true
 
@@ -17,7 +19,7 @@ trim_trailing_whitespace = true
 [*.{cs,csx,cake,fs,fsx,vb,vbx}]
 indent_style = tab
 
-file_header_template = Copyright (c) ktsu.dev\nAll rights reserved.\nLicensed under the MIT license.
+file_header_template = Copyright (c) 2023-2026 ktsu-dev contributors
 
 # Default severity for all .NET Code Style rules
 dotnet_analyzer_diagnostic.severity = error
@@ -504,3 +506,8 @@ indent_style = tab
 [*.sh]
 end_of_line = lf
 indent_size = 2
+
+# Windows batch scripts and Visual Studio solution files keep CRLF on every platform.
+# These match the eol=crlf pins in .gitattributes.
+[*.{cmd,bat,sln}]
+end_of_line = crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -4,20 +4,25 @@
 # Git Line Endings            #
 ###############################
 
-# Set default behaviour to automatically normalize line endings.
-* text=auto
+# Normalize all text files to LF in the repository, and check them out as LF on every
+# platform. The explicit eol overrides each machine's core.autocrlf, so the working tree
+# is byte-identical on Windows, Linux and macOS. This must stay in step with the
+# end_of_line settings in .editorconfig.
+* text=auto eol=lf
 
-# csharp files to match .editorconfig
-*.cs text eol=crlf
+# Force bash scripts to always use LF line endings so that if a repo is accessed
+# in Unix via a file share from Windows, the scripts will work. Redundant with the
+# default above, kept explicit because these files break outright with CRLF.
+*.sh text eol=lf
 
 # Force batch scripts to always use CRLF line endings so that if a repo is accessed
 # in Windows via a file share from Linux, the scripts will work.
-*.{cmd,[cC][mM][dD]} text eol=crlf
-*.{bat,[bB][aA][tT]} text eol=crlf
+*.cmd text eol=crlf
+*.bat text eol=crlf
 
-# Force bash scripts to always use LF line endings so that if a repo is accessed
-# in Unix via a file share from Windows, the scripts will work.
-*.sh text eol=lf
+# Visual Studio rewrites solution files with CRLF regardless of the checkout, so pin
+# them to avoid a spurious whole-file diff every time the solution is opened.
+*.sln text eol=crlf
 
 ###############################
 # Git Large File System (LFS) #

--- a/.runsettings
+++ b/.runsettings
@@ -1,25 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RunSettings>
-  <!-- Specify a deterministic output directory -->
   <RunConfiguration>
-    <ResultsDirectory>.\coverage</ResultsDirectory>
+    <ResultsDirectory>TestResults</ResultsDirectory>
   </RunConfiguration>
-  <!-- Specify a deterministic output directory -->
-  <RunConfiguration>
-    <ResultsDirectory>.\coverage</ResultsDirectory>
-  </RunConfiguration>
-
-  <!-- Configuration for coverlet data collector -->
-  <DataCollectionRunSettings>
-    <DataCollectors>
-      <DataCollector friendlyName="XPlat Code Coverage" uri="datacollector://Microsoft/CodeCoverage/2.0" assemblyQualifiedName="coverlet.collector.DataCollectors.CoverletInProcDataCollector, coverlet.collector, Version=6.0.4.0, Culture=neutral, PublicKeyToken=null">
-        <Configuration>
-          <Format>opencover</Format>
-          <OutputPath>coverage.opencover.xml</OutputPath>
-          <Exclude>[*Test*]*,[*Tests*]*</Exclude>
-          <ExcludeByFile>**/obj/**/*</ExcludeByFile>
-        </Configuration>
-      </DataCollector>
-    </DataCollectors>
-  </DataCollectionRunSettings>
 </RunSettings>

--- a/BlastMerge.ConsoleApp/CLI/CommandLineHandler.cs
+++ b/BlastMerge.ConsoleApp/CLI/CommandLineHandler.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.CLI;
 

--- a/BlastMerge.ConsoleApp/CLI/CommandLineOptions.cs
+++ b/BlastMerge.ConsoleApp/CLI/CommandLineOptions.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.CLI;
 

--- a/BlastMerge.ConsoleApp/CLI/ICommandLineHandler.cs
+++ b/BlastMerge.ConsoleApp/CLI/ICommandLineHandler.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.CLI;
 

--- a/BlastMerge.ConsoleApp/Contracts/HelpChoice.cs
+++ b/BlastMerge.ConsoleApp/Contracts/HelpChoice.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Contracts;
 

--- a/BlastMerge.ConsoleApp/Contracts/IMenuHandler.cs
+++ b/BlastMerge.ConsoleApp/Contracts/IMenuHandler.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Contracts;
 

--- a/BlastMerge.ConsoleApp/Contracts/SettingsChoice.cs
+++ b/BlastMerge.ConsoleApp/Contracts/SettingsChoice.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Contracts;
 

--- a/BlastMerge.ConsoleApp/Contracts/SyncChoice.cs
+++ b/BlastMerge.ConsoleApp/Contracts/SyncChoice.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Contracts;
 

--- a/BlastMerge.ConsoleApp/Models/AppDataHistoryInput.cs
+++ b/BlastMerge.ConsoleApp/Models/AppDataHistoryInput.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Models;
 

--- a/BlastMerge.ConsoleApp/Models/BatchActionChoice.cs
+++ b/BlastMerge.ConsoleApp/Models/BatchActionChoice.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Models;
 

--- a/BlastMerge.ConsoleApp/Models/BatchActionResult.cs
+++ b/BlastMerge.ConsoleApp/Models/BatchActionResult.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Models;
 

--- a/BlastMerge.ConsoleApp/Models/BatchOperationChoice.cs
+++ b/BlastMerge.ConsoleApp/Models/BatchOperationChoice.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Models;
 

--- a/BlastMerge.ConsoleApp/Models/BatchPatternResult.cs
+++ b/BlastMerge.ConsoleApp/Models/BatchPatternResult.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Models;
 

--- a/BlastMerge.ConsoleApp/Models/CompareChoice.cs
+++ b/BlastMerge.ConsoleApp/Models/CompareChoice.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Models;
 

--- a/BlastMerge.ConsoleApp/Models/HelpMenuChoice.cs
+++ b/BlastMerge.ConsoleApp/Models/HelpMenuChoice.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Models;
 

--- a/BlastMerge.ConsoleApp/Models/InputState.cs
+++ b/BlastMerge.ConsoleApp/Models/InputState.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Models;
 

--- a/BlastMerge.ConsoleApp/Models/MenuChoice.cs
+++ b/BlastMerge.ConsoleApp/Models/MenuChoice.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Models;
 

--- a/BlastMerge.ConsoleApp/Models/ProcessFileActionChoice.cs
+++ b/BlastMerge.ConsoleApp/Models/ProcessFileActionChoice.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Models;
 

--- a/BlastMerge.ConsoleApp/Program.cs
+++ b/BlastMerge.ConsoleApp/Program.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp;
 

--- a/BlastMerge.ConsoleApp/Services/AsyncApplicationService.cs
+++ b/BlastMerge.ConsoleApp/Services/AsyncApplicationService.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 #pragma warning disable CA2007 // Consider calling ConfigureAwait on the awaited task
 

--- a/BlastMerge.ConsoleApp/Services/Common/ComparisonOperationsService.cs
+++ b/BlastMerge.ConsoleApp/Services/Common/ComparisonOperationsService.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Services.Common;
 

--- a/BlastMerge.ConsoleApp/Services/Common/FileComparisonDisplayService.cs
+++ b/BlastMerge.ConsoleApp/Services/Common/FileComparisonDisplayService.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Services.Common;
 

--- a/BlastMerge.ConsoleApp/Services/Common/NavigationStack.cs
+++ b/BlastMerge.ConsoleApp/Services/Common/NavigationStack.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Services.Common;
 

--- a/BlastMerge.ConsoleApp/Services/Common/UIHelper.cs
+++ b/BlastMerge.ConsoleApp/Services/Common/UIHelper.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Services.Common;
 

--- a/BlastMerge.ConsoleApp/Services/ConsoleApplicationService.cs
+++ b/BlastMerge.ConsoleApp/Services/ConsoleApplicationService.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Services;
 

--- a/BlastMerge.ConsoleApp/Services/FileDisplayService.cs
+++ b/BlastMerge.ConsoleApp/Services/FileDisplayService.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Services;
 

--- a/BlastMerge.ConsoleApp/Services/InteractiveMergeService.cs
+++ b/BlastMerge.ConsoleApp/Services/InteractiveMergeService.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Services;
 

--- a/BlastMerge.ConsoleApp/Services/MenuDisplayService.cs
+++ b/BlastMerge.ConsoleApp/Services/MenuDisplayService.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Services;
 

--- a/BlastMerge.ConsoleApp/Services/MenuHandlers/BaseMenuHandler.cs
+++ b/BlastMerge.ConsoleApp/Services/MenuHandlers/BaseMenuHandler.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Services.MenuHandlers;
 

--- a/BlastMerge.ConsoleApp/Services/MenuHandlers/BatchOperationsMenuHandler.cs
+++ b/BlastMerge.ConsoleApp/Services/MenuHandlers/BatchOperationsMenuHandler.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Services.MenuHandlers;
 

--- a/BlastMerge.ConsoleApp/Services/MenuHandlers/CompareFilesMenuHandler.cs
+++ b/BlastMerge.ConsoleApp/Services/MenuHandlers/CompareFilesMenuHandler.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Services.MenuHandlers;
 

--- a/BlastMerge.ConsoleApp/Services/MenuHandlers/FindFilesMenuHandler.cs
+++ b/BlastMerge.ConsoleApp/Services/MenuHandlers/FindFilesMenuHandler.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Services.MenuHandlers;
 

--- a/BlastMerge.ConsoleApp/Services/MenuHandlers/HelpMenuHandler.cs
+++ b/BlastMerge.ConsoleApp/Services/MenuHandlers/HelpMenuHandler.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Services.MenuHandlers;
 

--- a/BlastMerge.ConsoleApp/Services/MenuHandlers/IterativeMergeMenuHandler.cs
+++ b/BlastMerge.ConsoleApp/Services/MenuHandlers/IterativeMergeMenuHandler.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Services.MenuHandlers;
 

--- a/BlastMerge.ConsoleApp/Services/MenuHandlers/SettingsMenuHandler.cs
+++ b/BlastMerge.ConsoleApp/Services/MenuHandlers/SettingsMenuHandler.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Services.MenuHandlers;
 

--- a/BlastMerge.ConsoleApp/Services/ProgressReportingService.cs
+++ b/BlastMerge.ConsoleApp/Services/ProgressReportingService.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Services;
 

--- a/BlastMerge.ConsoleApp/Services/SyncOperationsService.cs
+++ b/BlastMerge.ConsoleApp/Services/SyncOperationsService.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Services;
 

--- a/BlastMerge.ConsoleApp/Services/UserInteractionService.cs
+++ b/BlastMerge.ConsoleApp/Services/UserInteractionService.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Services;
 

--- a/BlastMerge.ConsoleApp/Text/ActionDisplay.cs
+++ b/BlastMerge.ConsoleApp/Text/ActionDisplay.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Text;
 

--- a/BlastMerge.ConsoleApp/Text/BatchManagementDisplay.cs
+++ b/BlastMerge.ConsoleApp/Text/BatchManagementDisplay.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Text;
 

--- a/BlastMerge.ConsoleApp/Text/BatchOperationsDisplay.cs
+++ b/BlastMerge.ConsoleApp/Text/BatchOperationsDisplay.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Text;
 

--- a/BlastMerge.ConsoleApp/Text/CommonMessages.cs
+++ b/BlastMerge.ConsoleApp/Text/CommonMessages.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Text;
 

--- a/BlastMerge.ConsoleApp/Text/CompareFilesDisplay.cs
+++ b/BlastMerge.ConsoleApp/Text/CompareFilesDisplay.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Text;
 

--- a/BlastMerge.ConsoleApp/Text/DiffFormatsDisplay.cs
+++ b/BlastMerge.ConsoleApp/Text/DiffFormatsDisplay.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Text;
 

--- a/BlastMerge.ConsoleApp/Text/InteractiveMergeText.cs
+++ b/BlastMerge.ConsoleApp/Text/InteractiveMergeText.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Text;
 

--- a/BlastMerge.ConsoleApp/Text/MainMenuDisplay.cs
+++ b/BlastMerge.ConsoleApp/Text/MainMenuDisplay.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Text;
 

--- a/BlastMerge.ConsoleApp/Text/MenuNames.cs
+++ b/BlastMerge.ConsoleApp/Text/MenuNames.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Text;
 

--- a/BlastMerge.ConsoleApp/Text/OutputDisplay.cs
+++ b/BlastMerge.ConsoleApp/Text/OutputDisplay.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Text;
 

--- a/BlastMerge.ConsoleApp/Text/SettingsDisplay.cs
+++ b/BlastMerge.ConsoleApp/Text/SettingsDisplay.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Text;
 

--- a/BlastMerge.ConsoleApp/Text/SyncOperationsDisplay.cs
+++ b/BlastMerge.ConsoleApp/Text/SyncOperationsDisplay.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.ConsoleApp.Text;
 

--- a/BlastMerge.Test/Adapters/FileDifferAdapter.cs
+++ b/BlastMerge.Test/Adapters/FileDifferAdapter.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test.Adapters;
 

--- a/BlastMerge.Test/Adapters/FileFinderAdapter.cs
+++ b/BlastMerge.Test/Adapters/FileFinderAdapter.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test.Adapters;
 

--- a/BlastMerge.Test/Adapters/FileHasherAdapter.cs
+++ b/BlastMerge.Test/Adapters/FileHasherAdapter.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test.Adapters;
 

--- a/BlastMerge.Test/Adapters/IFileDiffer.cs
+++ b/BlastMerge.Test/Adapters/IFileDiffer.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test.Adapters;
 

--- a/BlastMerge.Test/Adapters/IFileFinder.cs
+++ b/BlastMerge.Test/Adapters/IFileFinder.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test.Adapters;
 

--- a/BlastMerge.Test/Adapters/IFileHasher.cs
+++ b/BlastMerge.Test/Adapters/IFileHasher.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test.Adapters;
 

--- a/BlastMerge.Test/AppDataBatchManagerTests.cs
+++ b/BlastMerge.Test/AppDataBatchManagerTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/ApplicationServiceTests.cs
+++ b/BlastMerge.Test/ApplicationServiceTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/AsyncFileDifferTests.cs
+++ b/BlastMerge.Test/AsyncFileDifferTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/BatchProcessorTests.cs
+++ b/BlastMerge.Test/BatchProcessorTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/BlockMergerTests.cs
+++ b/BlastMerge.Test/BlockMergerTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/CharacterLevelDifferTests.cs
+++ b/BlastMerge.Test/CharacterLevelDifferTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/DiffPlexDifferTests.cs
+++ b/BlastMerge.Test/DiffPlexDifferTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/DiffPlexHelperTests.cs
+++ b/BlastMerge.Test/DiffPlexHelperTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/EdgeCaseTests.cs
+++ b/BlastMerge.Test/EdgeCaseTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/FileDifferDiffTests.cs
+++ b/BlastMerge.Test/FileDifferDiffTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/FileDifferGroupingTests.cs
+++ b/BlastMerge.Test/FileDifferGroupingTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/FileDifferPathTests.cs
+++ b/BlastMerge.Test/FileDifferPathTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/FileDisplayServiceTests.cs
+++ b/BlastMerge.Test/FileDisplayServiceTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/FileFinderTests.cs
+++ b/BlastMerge.Test/FileFinderTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/FileHasherTests.cs
+++ b/BlastMerge.Test/FileHasherTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/FileSystemProviderTests.cs
+++ b/BlastMerge.Test/FileSystemProviderTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/IntegrationTests.cs
+++ b/BlastMerge.Test/IntegrationTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/IterativeMergeOrchestratorTests.cs
+++ b/BlastMerge.Test/IterativeMergeOrchestratorTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/MockFileSystemTestBase.cs
+++ b/BlastMerge.Test/MockFileSystemTestBase.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/MockFileSystemTests.cs
+++ b/BlastMerge.Test/MockFileSystemTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/ModelTests.cs
+++ b/BlastMerge.Test/ModelTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/PerformanceTests.cs
+++ b/BlastMerge.Test/PerformanceTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/RecursiveDiffTests.cs
+++ b/BlastMerge.Test/RecursiveDiffTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/RequestModelTests.cs
+++ b/BlastMerge.Test/RequestModelTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/ResolutionItemTests.cs
+++ b/BlastMerge.Test/ResolutionItemTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/SecureTempFileHelperTests.cs
+++ b/BlastMerge.Test/SecureTempFileHelperTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/TestHelper.cs
+++ b/BlastMerge.Test/TestHelper.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge.Test/WhitespaceVisualizerTests.cs
+++ b/BlastMerge.Test/WhitespaceVisualizerTests.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Test;
 

--- a/BlastMerge/Contracts/IApplicationService.cs
+++ b/BlastMerge/Contracts/IApplicationService.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Contracts;
 

--- a/BlastMerge/Models/ApplicationSettings.cs
+++ b/BlastMerge/Models/ApplicationSettings.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/BatchConfiguration.cs
+++ b/BlastMerge/Models/BatchConfiguration.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/BatchRequest.cs
+++ b/BlastMerge/Models/BatchRequest.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/BatchResult.cs
+++ b/BlastMerge/Models/BatchResult.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/BlastMergeAppData.cs
+++ b/BlastMerge/Models/BlastMergeAppData.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/BlockChoice.cs
+++ b/BlastMerge/Models/BlockChoice.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/BlockContext.cs
+++ b/BlastMerge/Models/BlockContext.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/BlockType.cs
+++ b/BlastMerge/Models/BlockType.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/ColorCodePair.cs
+++ b/BlastMerge/Models/ColorCodePair.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/ColoredDiffLine.cs
+++ b/BlastMerge/Models/ColoredDiffLine.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/DiffBlock.cs
+++ b/BlastMerge/Models/DiffBlock.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/DiffBlockStatistics.cs
+++ b/BlastMerge/Models/DiffBlockStatistics.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/DiffColor.cs
+++ b/BlastMerge/Models/DiffColor.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/DiffStatistics.cs
+++ b/BlastMerge/Models/DiffStatistics.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/DirectoryComparisonResult.cs
+++ b/BlastMerge/Models/DirectoryComparisonResult.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/FileGroup.cs
+++ b/BlastMerge/Models/FileGroup.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/FileOperationResult.cs
+++ b/BlastMerge/Models/FileOperationResult.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/FileSimilarity.cs
+++ b/BlastMerge/Models/FileSimilarity.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/LineDifference.cs
+++ b/BlastMerge/Models/LineDifference.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/LineDifferenceType.cs
+++ b/BlastMerge/Models/LineDifferenceType.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/MergeCompletionResult.cs
+++ b/BlastMerge/Models/MergeCompletionResult.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/MergeConflict.cs
+++ b/BlastMerge/Models/MergeConflict.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/MergeOperationSummary.cs
+++ b/BlastMerge/Models/MergeOperationSummary.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/MergeResult.cs
+++ b/BlastMerge/Models/MergeResult.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/MergeSessionStatus.cs
+++ b/BlastMerge/Models/MergeSessionStatus.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/PatternResult.cs
+++ b/BlastMerge/Models/PatternResult.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/ProcessingRequest.cs
+++ b/BlastMerge/Models/ProcessingRequest.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/RecentBatchInfo.cs
+++ b/BlastMerge/Models/RecentBatchInfo.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Models/ResolutionItem.cs
+++ b/BlastMerge/Models/ResolutionItem.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Models;
 

--- a/BlastMerge/Services/AppDataBatchManager.cs
+++ b/BlastMerge/Services/AppDataBatchManager.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Services;
 

--- a/BlastMerge/Services/ApplicationService.cs
+++ b/BlastMerge/Services/ApplicationService.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Services;
 

--- a/BlastMerge/Services/AsyncFileDiffer.cs
+++ b/BlastMerge/Services/AsyncFileDiffer.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Services;
 

--- a/BlastMerge/Services/BatchProcessor.cs
+++ b/BlastMerge/Services/BatchProcessor.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Services;
 

--- a/BlastMerge/Services/BlockMerger.cs
+++ b/BlastMerge/Services/BlockMerger.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Services;
 

--- a/BlastMerge/Services/CharacterLevelDiffer.cs
+++ b/BlastMerge/Services/CharacterLevelDiffer.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Services;
 

--- a/BlastMerge/Services/DiffPlexDiffer.cs
+++ b/BlastMerge/Services/DiffPlexDiffer.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Services;
 

--- a/BlastMerge/Services/DiffPlexHelper.cs
+++ b/BlastMerge/Services/DiffPlexHelper.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Services;
 

--- a/BlastMerge/Services/FileDiffer.cs
+++ b/BlastMerge/Services/FileDiffer.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Services;
 

--- a/BlastMerge/Services/FileFinder.cs
+++ b/BlastMerge/Services/FileFinder.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Services;
 

--- a/BlastMerge/Services/FileHasher.cs
+++ b/BlastMerge/Services/FileHasher.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Services;
 

--- a/BlastMerge/Services/FileSystemProvider.cs
+++ b/BlastMerge/Services/FileSystemProvider.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Services;
 

--- a/BlastMerge/Services/IterativeMergeOrchestrator.cs
+++ b/BlastMerge/Services/IterativeMergeOrchestrator.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Services;
 

--- a/BlastMerge/Services/SecureTempFileHelper.cs
+++ b/BlastMerge/Services/SecureTempFileHelper.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Services;
 

--- a/BlastMerge/Services/WhitespaceVisualizer.cs
+++ b/BlastMerge/Services/WhitespaceVisualizer.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Services;
 

--- a/BlastMerge/Text/ProgressMessages.cs
+++ b/BlastMerge/Text/ProgressMessages.cs
@@ -1,6 +1,4 @@
-// Copyright (c) ktsu.dev
-// All rights reserved.
-// Licensed under the MIT license.
+// Copyright (c) 2023-2026 ktsu-dev contributors
 
 namespace ktsu.BlastMerge.Text;
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,13 +6,11 @@
     <PackageVersion Include="CommandLineParser" Version="2.9.1" />
     <PackageVersion Include="DiffPlex" Version="1.8.0" />
     <PackageVersion Include="ktsu.AppDataStorage" Version="1.15.6" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.CodeCoverage" Version="17.14.2" />
     <PackageVersion Include="Microsoft.Testing.Extensions.CrashDump" Version="1.7.2" />
     <PackageVersion Include="Microsoft.Testing.Extensions.Fakes" Version="17.14.1" />
     <PackageVersion Include="Microsoft.Testing.Extensions.HangDump" Version="1.7.2" />
     <PackageVersion Include="Microsoft.Testing.Extensions.HotReload" Version="1.7.2" />
     <PackageVersion Include="Microsoft.Testing.Extensions.Retry" Version="1.7.2" />
-    <PackageVersion Include="Microsoft.Testing.Extensions.TrxReport" Version="1.7.2" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Spectre.Console" Version="0.50.0" />
     <PackageVersion Include="TestableIO.System.IO.Abstractions" Version="22.0.14" />

--- a/global.json
+++ b/global.json
@@ -5,15 +5,15 @@
   },
   "msbuild-sdks": {
     "MSTest.Sdk": "4.3.3",
-    "ktsu.Sdk": "2.16.1",
-    "ktsu.Sdk.ConsoleApp": "2.16.1",
-    "ktsu.Sdk.Tool": "2.16.1",
-    "ktsu.Sdk.App": "2.16.1",
-    "ktsu.Sdk.Windows": "2.16.1",
-    "ktsu.Sdk.Linux": "2.16.1",
-    "ktsu.Sdk.macOS": "2.16.1",
-    "ktsu.Sdk.iOS": "2.16.1",
-    "ktsu.Sdk.Android": "2.16.1"
+    "ktsu.Sdk": "2.21.1",
+    "ktsu.Sdk.ConsoleApp": "2.21.1",
+    "ktsu.Sdk.Tool": "2.21.1",
+    "ktsu.Sdk.App": "2.21.1",
+    "ktsu.Sdk.Windows": "2.21.1",
+    "ktsu.Sdk.Linux": "2.21.1",
+    "ktsu.Sdk.macOS": "2.21.1",
+    "ktsu.Sdk.iOS": "2.21.1",
+    "ktsu.Sdk.Android": "2.21.1"
   },
   "test": {
     "runner": "Microsoft.Testing.Platform"


### PR DESCRIPTION
Bumps ktsu.Sdk and its variants to 2.21.1 in global.json.  File headers are migrated to the single line from COPYRIGHT.md, which is what the SDK writes into .editorconfig as file_header_template and IDE0073 enforces.  Removes the PackageVersion entries for Microsoft.Testing.Extensions.CodeCoverage and TrxReport, which MSTest.Sdk 4.3.3 now supplies itself (NU1506).  

Generated with [Claude Code](https://claude.com/claude-code)
